### PR TITLE
Require specific Machinekit-HAL package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,16 @@ curl -1sLf \
   | sudo -E bash
 git clone https://github.com/machinekit/emcapplication.git
 cd emcapplication
-sudo apt install build-essential fakeroot devscripts python
-debian/configure machinekit-hal no-docs
-mk-build-deps -irs sudo
+sudo apt install build-essential fakeroot devscripts python apt-cudf
+sudo apt-mark hold machinekit-hal
+debian/configure machinekit-hal=${WANTED_VERSION_OF_MACHINEKIT_HAL_PACKAGES} no-docs
+mk-build-deps       \
+    --install       \
+    --remove        \
+    --root-cmd sudo \
+    --tool          \
+    'apt-cudf-get --solver aspcud -o APT::Get::Assume-Yes=1 -o Debug::pkgProblemResolver=0 -o APT::Install-Recommends=0' \
+    debian/control
 cd src
 ./autogen.sh
 ./configure --with-hal=machinekit-hal
@@ -90,6 +97,7 @@ make
 sudo make install
 cd ..
 source ./scripts/rip-environment
+linuxcnc
 ```
 
 |![Warning](https://img.icons8.com/ios-filled/50/000000/warning-shield.png)| Be advised that currently there is no support for Linux distributions other than Debian. |

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -9,5 +9,6 @@ linuxcnc-uspace-dev
 linuxcnc-doc-*/
 *.substvars
 /linuxcnc*.files
+/emcapplication*.files
 *.debhelper
 shlibs.local

--- a/debian/configure
+++ b/debian/configure
@@ -241,6 +241,8 @@ PC based motion controller for real-time Linux
  alternate front-ends for linuxcnc
 DESCRIPTION
 OTHER_CONFLICTING_PACKAGES=""
+VCS_BROWSER="https://github.com/LinuxCNC/linuxcnc"
+VCS_GIT="git://github.com/linuxcnc/linuxcnc.git"
 
 case $TARGET in
     uspace|sim)
@@ -312,6 +314,8 @@ Enhanced Motion Controller for Machinekit-HAL
 DESCRIPTION
     OTHER_CONFLICTING_PACKAGES=", linuxcnc, linuxcnc-dev, machinekit-cnc"
     MAINTAINER="Machinekit Bot <machinekit@eryaf.com>"
+    VCS_BROWSER="https://github.com/machinekit/EMCApplication"
+    VCS_GIT="https://github.com/machinekit/emcapplication.git"
     ;;
     2.6.32-122-rtai|3.4-9-rtai-686-pae|3.16.0-9-rtai-*)
         CONFIGURE_REALTIME_ARG=--with-realtime=/usr/realtime-$KERNEL_VERSION
@@ -364,6 +368,8 @@ sed \
     -e "s#@MAIN_PACKAGE_DESCRIPTION_TEXT@#$MAIN_PACKAGE_DESCRIPTION_TEXT#g" \
     -e "s#@DEV_PACKAGE_DESCRIPTION_TEXT@#$DEV_PACKAGE_DESCRIPTION_TEXT#g" \
     -e "s#@MAINTAINER@#$MAINTAINER#g" \
+    -e "s#@VCS_BROWSER@#$VCS_BROWSER#g" \
+    -e "s#@VCS_GIT@#$VCS_GIT#g" \
     $*
 }
 
@@ -391,7 +397,7 @@ do_emcapplication_changelog() {
     DISTRO_UC="$(echo $DISTRO_CODENAME | sed 's/^[[:space:]]*//g' | sed -e 's/\b\(.\)/\u\1/g')"
     DISTRO_LC="$(echo $DISTRO_CODENAME | sed 's/^[[:space:]]*//g')"
     COMMIT_COUNT="$(git rev-list --count HEAD)"
-    EMCAVERSION="$(git show HEAD:VERSION | cut -d ' ' -f 1).${COMMIT_COUNT}-1.git$(git rev-parse --short HEAD)~${DISTRO_LC}"
+    EMCAVERSION="$(git show HEAD:VERSION | cut -d ' ' -f 1).${COMMIT_COUNT}.git$(git rev-parse --short HEAD)~${DISTRO_LC}"
     COMMIT="$(git rev-parse HEAD)"
     AUTHOR_NAME="$(git show -s --pretty=%an $COMMIT)"
     AUTHOR_EMAIL="$(git show -s --format='%ae' $COMMIT)"

--- a/debian/configure
+++ b/debian/configure
@@ -281,11 +281,20 @@ case $TARGET in
         EXTRA_RECOMMENDS="$EXTRA_RECOMMENDS, linux-image-rt-amd64 [linux-amd64], linux-image-rt-686-pae [linux-i386]"
         CONFIGURE_REALTIME_ARG=--with-realtime=uspace
     ;;
-    machinekit-hal)
+    machinekit-hal*)
+    MACHINEKIT_HAL_ARR=(${TARGET//=/ })
+    MACHINEKIT_VERSION=${MACHINEKIT_HAL_ARR[1]}
+    if [ -z "$MACHINEKIT_VERSION" ]
+    then
+        printf "%b"                                                          \
+               "Version of Machinekit-HAL packages have to be specified as " \
+               "configure machinekit-hal=\${VERSION}\n"
+        exit 1
+    fi
 	TARGET=machinekit-hal
         MODULE_PATH=usr/lib/machinekit/modules
 	MODULE_EXT=.so
-        KERNEL_DEPENDS="machinekit-hal (>= 0.4)"
+        KERNEL_DEPENDS="machinekit-hal (= $MACHINEKIT_VERSION)"
 	KERNEL_HEADERS=
 	KERNEL_VERSION=machinekit-hal
         MODUTILS_DEPENDS=
@@ -296,8 +305,8 @@ case $TARGET in
         OTHER_MAIN_PACKAGE_NAME=linuxcnc-uspace
         INITRD_REALTIME_PATH=
         CONFIGURE_REALTIME_ARG=--with-hal=machinekit-hal
-    EXTRA_BUILD="${EXTRA_BUILD}, machinekit-hal-dev (>= 0.4)"
-    EXTRA_RECOMMENDS="machinekit-hal-dev"
+    EXTRA_BUILD="${EXTRA_BUILD}, machinekit-hal-dev (= $MACHINEKIT_VERSION)"
+    EXTRA_RECOMMENDS="machinekit-hal-dev (= $MACHINEKIT_VERSION)"
     read -r -d '' MAIN_PACKAGE_DESCRIPTION_TEXT <<DESCRIPTION
 Enhanced Motion Controller for Machinekit-HAL
  Run EMC2 developed as part of LinuxCNC with the power of Machinekit-HAL engine

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -35,8 +35,8 @@ Build-Depends: debhelper (>= 6),
     yapps2,
     libtirpc-dev
 Standards-Version: @STANDARDS_VERSION@
-Vcs-Browser: https://github.com/LinuxCNC/linuxcnc
-Vcs-Git: git://github.com/linuxcnc/linuxcnc.git
+Vcs-Browser: @VCS_BROWSER@
+Vcs-Git: @VCS_GIT@
 
 Package: @MAIN_PACKAGE_NAME@-dev
 Architecture: any

--- a/debian/emcapplication.files.in
+++ b/debian/emcapplication.files.in
@@ -20,6 +20,7 @@ usr/share/glade3
 usr/share/doc/linuxcnc/asciidoc-markup.txt
 usr/share/doc/linuxcnc/gcode.html
 usr/share/doc/linuxcnc/gcode_fr.html
+usr/share/doc/linuxcnc/gcode_es.html
 usr/share/doc/linuxcnc/gcode_vi.html
 usr/share/doc/linuxcnc/AUTHORS
 usr/share/doc/linuxcnc/axis_light_background
@@ -29,6 +30,7 @@ usr/share/doc/linuxcnc/README.axis
 usr/share/doc/linuxcnc/examples/nc_files
 usr/share/doc/linuxcnc/examples/sample-configs/*/*
 usr/share/doc/linuxcnc/examples/sample-configs/maintainer.txt
+usr/share/doc/linuxcnc/examples/sample-configs/maintainer_es.txt
 usr/share/linuxcnc/*
 usr/share/locale/*/LC_MESSAGES/*.mo
 usr/share/gtksourceview-2.0/


### PR DESCRIPTION
This pull request implements package locking to specific version of `machinekit-hal` packages as mentioned in issue #2. The new functionality works by requiring parameter when running the `debian/configure` bash script:

```
./debian/configure machinekit-hal=${WANTED_MACHINEKIT_HALPACKAGE_VERSION} no-docs
# For example for latest Python 2 Machinekit-HAL
./debian/configure machinekit-hal=0.4.20894-1.gitebe1344a0~$(lsb_release -cs) no-docs
```

It will create a `debian/control` file with specified versions:

```
Source: linuxcnc
Section: misc
Priority: optional
Maintainer: Machinekit Bot <machinekit@eryaf.com>
Build-Depends: debhelper (>= 6),
    dh-python,
    machinekit-hal (= 0.4.20894-1.gitebe1344a0~buster),
    ,
    ,
    python-yapps, machinekit-hal-dev (= 0.4.20894-1.gitebe1344a0~buster),
    tcl8.6-dev,
    tk8.6-dev,
    libtk-img,
    bwidget (>= 1.7),
    tclx,
    libreadline-gplv2-dev,
    , asciidoc-dblatex,
    python,
    python-dev,
    python-tk,
    libxmu-dev,
    libglu1-mesa-dev,
    libgl1-mesa-dev | libgl1-mesa-swx11-dev,
    libgtk2.0-dev,
    gettext,
    intltool,
    autoconf,
    libboost-python-dev,
    netcat,
    libmodbus-dev (>= 3.0),
    libusb-1.0-0-dev,
    procps,
    psmisc,
    desktop-file-utils,
    yapps2,
    libtirpc-dev
Standards-Version: 3.9.8
Vcs-Browser: https://github.com/machinekit/EMCApplication
Vcs-Git: https://github.com/machinekit/emcapplication.git

Package: emcapplication-dev
Architecture: any
Conflicts: linuxcnc-sim-dev, linuxcnc-uspace-dev , linuxcnc, linuxcnc-dev, machinekit-cnc
Depends: g++, ,
    python-serial,
    python (>= 2.7), python (<< 2.8),
    ${python:Depends}, ${misc:Depends},
    emcapplication (= ${binary:Version}),
    udev,
    python-yapps
Section: libs
Description: Enhanced Motion Controller for Machinekit-HAL
 Run EMC2 developed as part of LinuxCNC with the power of Machinekit-HAL engine
 Provides CNC capability and HMI for various applications (milling, cutting,
 routing, etc.).
 .
 This package includes files needed for development and testing

Package: emcapplication
Conflicts: linuxcnc-sim, linuxcnc-uspace , linuxcnc, linuxcnc-dev, machinekit-cnc
Architecture: any
Recommends: linuxcnc-doc-en | linuxcnc-doc, machinekit-hal-dev (= 0.4.20894-1.gitebe1344a0~buster)
Depends: ${shlibs:Depends}, machinekit-hal (= 0.4.20894-1.gitebe1344a0~buster),
    tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>=1.13),
    python (>= 2.7), python (<< 2.8),
    ${python:Depends}, ${misc:Depends},
    python2.7-tk,
    python2.7-glade2 | python-glade2,
    python2.7-numpy | python-numpy,
    python2.7-imaging | python-imaging | python-pil,
    python2.7-imaging-tk | python-imaging-tk | python-pil.imagetk,
    python-gtksourceview2,
    python-vte | gir1.2-vte-2.91,
    python-gst-1.0,gstreamer1.0-plugins-base,
    python-xlib, python-gtkglext1, python-configobj,
    tclreadline, procps, psmisc, tclx, ,
    mesa-utils, blt, udev
Description: Enhanced Motion Controller for Machinekit-HAL
 Run EMC2 developed as part of LinuxCNC with the power of Machinekit-HAL engine
 Provides CNC capability and HMI for various applications (milling, cutting,
 routing, etc.).
```

Because of the problem with package solver in standard Debian _apt_ when running the _mk-build-deps_, there is need for additional package name _apt-cudf_, which allows using smarter dependency solver:

```
mk-build-deps       \
    --install       \
    --remove        \
    --root-cmd sudo \
    --tool          \
    'apt-cudf-get --solver aspcud -o APT::Get::Assume-Yes=1 -o Debug::pkgProblemResolver=0 -o APT::Install-Recommends=0' \
    debian/control
```

This simpler implementation over the more _magical_ one - the first idea was using `dpkg` to look for installed packages of `machinekit-hal` plus `machinekit-hal-dev` and lock to this version or download available version data from Machinekit's repository - was chosen after realization that this functionality is already part of _apt_ and that CI (or user) should look for available versions as the address of remote repository is not known.

This change is already documented in pull request machinekit/machinekit-docs#320.